### PR TITLE
Use icons for settings and reset buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,8 +653,12 @@
                   <div aria-live="polite" ref={scoreLiveRef} className="text-5xl font-extrabold tracking-tight">{state.currentScore}</div>
                   <div className="flex items-center gap-2 mt-1 text-xs opacity-70">
                     <span>Leg status: {state.status === "playing" ? "In play" : "Won"}</span>
-                    <TwButton size="sm" variant="outline" onClick={() => resetLeg()}>Reset</TwButton>
-                    <TwButton size="sm" variant="outline" onClick={() => setShowControls(true)}>Settings</TwButton>
+                    <TwButton size="sm" variant="outline" onClick={() => resetLeg()} aria-label="Reset">
+                      <span aria-hidden="true">🔄</span>
+                    </TwButton>
+                    <TwButton size="sm" variant="outline" onClick={() => setShowControls(true)} aria-label="Settings">
+                      <span aria-hidden="true">⚙️</span>
+                    </TwButton>
                   </div>
                 </div>
               <div className="text-right">


### PR DESCRIPTION
## Summary
- Replace Reset and Settings text buttons with icon buttons for a cleaner interface

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a87726eca48329980c3f2985d9b985