### PR TITLE
Add top-level header with app name and settings control

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,7 +675,15 @@
 
         return (
           <div className="mx-auto max-w-md min-h-[100dvh] bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
-            {/* Header / Score */}
+            {/* App Header */}
+            <header className="flex items-center justify-between">
+              <div className="text-lg font-semibold">Dart Trainer</div>
+              <TwButton size="sm" variant="outline" onClick={() => setShowControls(true)} aria-label="Settings">
+                <span aria-hidden="true">⚙️</span>
+              </TwButton>
+            </header>
+
+            {/* Score */}
             <header className="flex items-center justify-between gap-3">
                 <div>
                   <div className="text-xs opacity-70">Remaining</div>
@@ -684,9 +692,6 @@
                     <span>Leg status: {state.status === "playing" ? "In play" : "Won"}</span>
                     <TwButton size="sm" variant="outline" onClick={() => resetLeg()} aria-label="Reset">
                       <span aria-hidden="true">🔄</span>
-                    </TwButton>
-                    <TwButton size="sm" variant="outline" onClick={() => setShowControls(true)} aria-label="Settings">
-                      <span aria-hidden="true">⚙️</span>
                     </TwButton>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Add a top bar displaying "Dart Trainer"
- Move settings button to new header and remove from score section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88037e3c083298d360af1838ad25c