### PR TITLE
Add reusable header component

### DIFF
--- a/header.js
+++ b/header.js
@@ -1,0 +1,10 @@
+function renderHeader() {
+  const header = document.createElement('header');
+  header.textContent = 'Darts Scorer';
+  header.className = 'p-4 text-2xl font-bold';
+  document.body.prepend(header);
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { renderHeader };
+}

--- a/index.html
+++ b/index.html
@@ -31,6 +31,10 @@
     </style>
   </head>
   <body class="bg-background text-foreground">
+    <script src="header.js"></script>
+    <script>
+      renderHeader();
+    </script>
     <div class="min-h-screen flex flex-col items-center justify-center gap-10 p-4">
       <h1 class="text-3xl font-bold">Select Game Mode</h1>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-5xl">

--- a/quickplay.html
+++ b/quickplay.html
@@ -38,6 +38,10 @@
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body class="bg-background text-foreground">
+    <script src="header.js"></script>
+    <script>
+      renderHeader();
+    </script>
     <div id="root"></div>
 
     <script type="text/babel">
@@ -685,19 +689,11 @@
 
         return (
           <div className="mx-auto max-w-md min-h-[100dvh] bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
-            {/* App Header */}
-            <header className="flex items-center justify-between">
-              <div className="text-lg font-semibold">Dart Trainer</div>
-              <TwButton size="sm" variant="outline" onClick={() => setShowControls(true)} aria-label="Settings">
-                <span aria-hidden="true">⚙️</span>
-              </TwButton>
-            </header>
-
             {/* Score */}
             <header className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-xs opacity-70">Remaining</div>
-                  <div aria-live="polite" ref={scoreLiveRef} className="text-5xl font-extrabold tracking-tight">{liveScore}</div>
+              <div>
+                <div className="text-xs opacity-70">Remaining</div>
+                <div aria-live="polite" ref={scoreLiveRef} className="text-5xl font-extrabold tracking-tight">{liveScore}</div>
                   <div className="flex items-center gap-2 mt-1 text-xs opacity-70">
                     <span>Leg status: {state.status === "playing" ? "In play" : "Won"}</span>
                     <TwButton size="sm" variant="outline" onClick={() => resetLeg()} aria-label="Reset">


### PR DESCRIPTION
## Summary
- add `header.js` to render a shared header with brand text
- load and invoke the header renderer on `index.html` and `quickplay.html`
- remove duplicate header block from `quickplay.html`

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88605a91083298485246866926415