### PR TITLE
feat: centralize settings overlay

### DIFF
--- a/global-header.js
+++ b/global-header.js
@@ -5,11 +5,19 @@ document.addEventListener('DOMContentLoaded', () => {
   header.innerHTML = `
     <div class="max-w-5xl mx-auto flex items-center justify-between p-4">
       <a href="index.html" class="text-lg font-bold">Darts Scorer</a>
-      <button id="menuButton" aria-label="Menu" aria-controls="globalMenu" aria-expanded="false" class="p-2 rounded-md focus:outline-none focus:ring">
-        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-        </svg>
-      </button>
+      <div class="flex items-center gap-2">
+        <button id="settingsButton" aria-label="Settings" class="p-2 rounded-md focus:outline-none focus:ring">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.591 1.054c1.543-.895 3.37.932 2.475 2.475a1.724 1.724 0 001.055 2.592c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.054 2.591c.895 1.543-.932 3.37-2.475 2.475a1.724 1.724 0 00-2.592 1.055c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.591-1.054c-1.543.895-3.37-.932-2.475-2.475a1.724 1.724 0 00-1.055-2.592c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.054-2.591c-.895-1.543.932-3.37 2.475-2.475a1.724 1.724 0 002.592-1.055z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+          </svg>
+        </button>
+        <button id="menuButton" aria-label="Menu" aria-controls="globalMenu" aria-expanded="false" class="p-2 rounded-md focus:outline-none focus:ring">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+      </div>
     </div>
     <nav id="globalMenu" class="hidden flex-col px-4 pb-4 space-y-2" role="navigation">
       <a href="quickplay.html" class="block px-3 py-2 rounded hover:bg-muted focus:bg-muted focus:outline-none">Quick Play</a>
@@ -22,11 +30,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const button = header.querySelector('#menuButton');
   const menu = header.querySelector('#globalMenu');
+  const settingsBtn = header.querySelector('#settingsButton');
 
   button.addEventListener('click', () => {
     const expanded = button.getAttribute('aria-expanded') === 'true';
     button.setAttribute('aria-expanded', String(!expanded));
     menu.classList.toggle('hidden', expanded);
+  });
+
+  settingsBtn.addEventListener('click', () => {
+    if (window.Settings && typeof window.Settings.openSettings === 'function') {
+      window.Settings.openSettings();
+    }
   });
 
   document.addEventListener('keydown', (e) => {

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
       .bg-muted { background-color: #f4f4f5; }
       .dark .bg-muted { background-color: rgba(39,39,42,0.4); }
     </style>
+    <script src="settings.js"></script>
     <script src="global-header.js" defer></script>
   </head>
   <body class="bg-background text-foreground">

--- a/quickplay.html
+++ b/quickplay.html
@@ -30,6 +30,7 @@
       .dark .bg-muted { background-color: rgba(39,39,42,0.4); }
     </style>
 
+    <script src="settings.js"></script>
     <script src="global-header.js" defer></script>
 
     <!-- React (production) + ReactDOM -->
@@ -58,20 +59,11 @@
       // Classic no 3-dart checkout numbers (bogeys)
       const NO_CHECKOUT_3_DART = new Set([169, 168, 166, 165, 163, 162, 159]);
 
-      const ALL_DOUBLES = Array.from({ length: 20 }, (_, i) => (i + 1) * 2).concat([50]);
-
-      const DEFAULT_SETTINGS = {
-        favouriteDouble: 32, // D16
-        theme: "system",
-        sound: false,
-      };
-
       /*************************
        * Utility – Local Storage
        *************************/
 
       const LS_STATE_KEY = "dartscorer_state_v1";
-      const LS_SETTINGS_KEY = "dartscorer_settings_v1";
 
       function loadState() {
         try {
@@ -86,22 +78,6 @@
       function saveState(state) {
         try {
           localStorage.setItem(LS_STATE_KEY, JSON.stringify(state));
-        } catch {}
-      }
-
-      function loadSettings() {
-        try {
-          const raw = localStorage.getItem(LS_SETTINGS_KEY);
-          if (!raw) return DEFAULT_SETTINGS;
-          return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
-        } catch {
-          return DEFAULT_SETTINGS;
-        }
-      }
-
-      function saveSettings(s) {
-        try {
-          localStorage.setItem(LS_SETTINGS_KEY, JSON.stringify(s));
         } catch {}
       }
 
@@ -429,53 +405,14 @@
       }
 
       /*************************
-       * Hooks: theme & sound
-       *************************/
-
-      function useTheme(setting) {
-        useEffect(() => {
-          const root = document.documentElement;
-          const systemDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
-          const shouldDark = setting === "dark" || (setting === "system" && systemDark);
-          root.classList.toggle("dark", shouldDark);
-        }, [setting]);
-      }
-
-      function useBeep(enabled) {
-        const ctxRef = useRef(null);
-        function play() {
-          if (!enabled) return;
-          try {
-            if (!ctxRef.current) {
-              const AC = window.AudioContext || window.webkitAudioContext;
-              if (!AC) return;
-              ctxRef.current = new AC();
-            }
-            const ctx = ctxRef.current;
-            const o = ctx.createOscillator();
-            const g = ctx.createGain();
-            o.type = "triangle";
-            o.frequency.value = 880;
-            g.gain.value = 0.0025;
-            o.connect(g);
-            g.connect(ctx.destination);
-            o.start();
-            setTimeout(() => o.stop(), 120);
-          } catch {}
-        }
-        return play;
-      }
-
-      /*************************
        * Main App Component
        *************************/
 
       function MobileScorer() {
         // Settings
-        const [settings, setSettings] = useState(() => loadSettings());
-        useTheme(settings.theme);
-        useEffect(() => saveSettings(settings), [settings]);
-        const beep = useBeep(settings.sound);
+        const [settings] = Settings.useSettings();
+        Settings.useTheme(settings.theme);
+        const beep = Settings.useBeep(settings.sound);
 
         // Game state
         const [state, setState] = useState(() => loadState() || { currentScore: START_SCORE, turns: [], status: "playing" });
@@ -488,10 +425,9 @@
           [state.currentScore, currentDarts]
         );
 
-          // UI
-          const [toast, setToast] = useState(null);
-          const toastTimeout = useRef(null);
-          const [showControls, setShowControls] = useState(false);
+        // UI
+        const [toast, setToast] = useState(null);
+        const toastTimeout = useRef(null);
 
         function showToast(msg) {
           setToast(msg);
@@ -859,56 +795,6 @@
                   </div>
                 </div>
               </div>
-              )}
-
-              {/* Settings Screen */}
-              {showControls && (
-                <div className="fixed inset-0 bg-background text-foreground p-4 z-50 overflow-auto" role="dialog" aria-modal>
-                  <div className="max-w-md mx-auto flex flex-col gap-4">
-                    <div className="flex items-center justify-between">
-                      <div className="text-lg font-semibold">Settings</div>
-                      <TwButton size="sm" variant="outline" onClick={() => setShowControls(false)}>Exit</TwButton>
-                    </div>
-                    <Card>
-                      <CardBody className="flex flex-col gap-3">
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <div className="text-sm font-medium">Favourite double</div>
-                            <div className="text-xs opacity-70">Bias checkout routes (2..40 even, or 50 for Bull)</div>
-                          </div>
-                          <select
-                            aria-label="Favourite double"
-                            value={settings.favouriteDouble}
-                            onChange={(e) => setSettings((s) => ({ ...s, favouriteDouble: parseInt(e.target.value, 10) }))}
-                            className="rounded-xl border bg-background px-3 py-2"
-                          >
-                            {ALL_DOUBLES.map((d) => (
-                              <option key={d} value={d}>{d === 50 ? "Bull (50)" : `D${d/2} (${d})`}</option>
-                            ))}
-                          </select>
-                        </div>
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <div className="text-sm font-medium">Theme</div>
-                            <div className="text-xs opacity-70">Follows system by default</div>
-                          </div>
-                          <div className="flex gap-2">
-                            <TwButton variant={settings.theme === "system" ? "solid" : "outline"} onClick={() => setSettings((s) => ({ ...s, theme: "system" }))}>System</TwButton>
-                            <TwButton variant={settings.theme === "light" ? "solid" : "outline"} onClick={() => setSettings((s) => ({ ...s, theme: "light" }))}>Light</TwButton>
-                            <TwButton variant={settings.theme === "dark" ? "solid" : "outline"} onClick={() => setSettings((s) => ({ ...s, theme: "dark" }))}>Dark</TwButton>
-                          </div>
-                        </div>
-                        <div className="flex items-center justify-between gap-3">
-                          <div>
-                            <div className="text-sm font-medium">Sound on checkout</div>
-                            <div className="text-xs opacity-70">Tiny beep when leg is won</div>
-                          </div>
-                          <TwButton variant={settings.sound ? "solid" : "outline"} onClick={() => setSettings((s) => ({ ...s, sound: !s.sound }))}>{settings.sound ? "On" : "Off"}</TwButton>
-                        </div>
-                      </CardBody>
-                    </Card>
-                  </div>
-                </div>
               )}
 
               {/* Toast */}

--- a/settings.js
+++ b/settings.js
@@ -1,0 +1,201 @@
+(function(){
+  const LS_SETTINGS_KEY = 'dartscorer_settings_v1';
+  const DEFAULT_SETTINGS = { favouriteDouble: 32, theme: 'system', sound: false };
+  const ALL_DOUBLES = Array.from({ length: 20 }, (_, i) => (i + 1) * 2).concat([50]);
+
+  function loadSettings() {
+    try {
+      const raw = localStorage.getItem(LS_SETTINGS_KEY);
+      if (!raw) return DEFAULT_SETTINGS;
+      return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+    } catch {
+      return DEFAULT_SETTINGS;
+    }
+  }
+
+  function saveSettings(s) {
+    try {
+      localStorage.setItem(LS_SETTINGS_KEY, JSON.stringify(s));
+    } catch {}
+  }
+
+  let currentSettings = loadSettings();
+
+  function applyTheme(setting) {
+    const root = document.documentElement;
+    const systemDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const shouldDark = setting === 'dark' || (setting === 'system' && systemDark);
+    root.classList.toggle('dark', shouldDark);
+  }
+
+  function setSettings(update) {
+    const next = typeof update === 'function' ? update(currentSettings) : update;
+    currentSettings = { ...currentSettings, ...next };
+    saveSettings(currentSettings);
+    applyTheme(currentSettings.theme);
+    document.dispatchEvent(new CustomEvent('settingschange', { detail: currentSettings }));
+  }
+
+  function getSettings() {
+    return currentSettings;
+  }
+
+  function useSettings() {
+    const [settings, setState] = React.useState(getSettings());
+    React.useEffect(() => {
+      const handler = (e) => setState(e.detail);
+      document.addEventListener('settingschange', handler);
+      return () => document.removeEventListener('settingschange', handler);
+    }, []);
+    return [settings, setSettings];
+  }
+
+  function useTheme(setting) {
+    React.useEffect(() => {
+      applyTheme(setting);
+    }, [setting]);
+  }
+
+  function useBeep(enabled) {
+    const ctxRef = React.useRef(null);
+    function play() {
+      if (!enabled) return;
+      try {
+        if (!ctxRef.current) {
+          const AC = window.AudioContext || window.webkitAudioContext;
+          if (!AC) return;
+          ctxRef.current = new AC();
+        }
+        const ctx = ctxRef.current;
+        const o = ctx.createOscillator();
+        const g = ctx.createGain();
+        o.type = 'triangle';
+        o.frequency.value = 880;
+        g.gain.value = 0.0025;
+        o.connect(g);
+        g.connect(ctx.destination);
+        o.start();
+        setTimeout(() => o.stop(), 120);
+      } catch {}
+    }
+    return play;
+  }
+
+  let overlayEl, selectEl, systemBtn, lightBtn, darkBtn, soundBtn;
+
+  function updateOverlayUI() {
+    if (!overlayEl) return;
+    const s = getSettings();
+    if (selectEl) selectEl.value = String(s.favouriteDouble);
+    const buttons = [systemBtn, lightBtn, darkBtn];
+    const themes = ['system', 'light', 'dark'];
+    buttons.forEach((btn, idx) => {
+      if (!btn) return;
+      if (s.theme === themes[idx]) {
+        btn.classList.add('bg-foreground', 'text-background');
+        btn.classList.remove('border', 'border-border');
+      } else {
+        btn.classList.remove('bg-foreground', 'text-background');
+        btn.classList.add('border', 'border-border');
+      }
+    });
+    if (soundBtn) {
+      soundBtn.textContent = s.sound ? 'On' : 'Off';
+      if (s.sound) {
+        soundBtn.classList.add('bg-foreground', 'text-background');
+        soundBtn.classList.remove('border', 'border-border');
+      } else {
+        soundBtn.classList.remove('bg-foreground', 'text-background');
+        soundBtn.classList.add('border', 'border-border');
+      }
+    }
+  }
+
+  function buildOverlay() {
+    overlayEl = document.createElement('div');
+    overlayEl.className = 'hidden fixed inset-0 bg-background text-foreground p-4 z-50 overflow-auto';
+    overlayEl.setAttribute('role', 'dialog');
+    overlayEl.setAttribute('aria-modal', 'true');
+    overlayEl.innerHTML = `
+      <div class="max-w-md mx-auto flex flex-col gap-4">
+        <div class="flex items-center justify-between">
+          <div class="text-lg font-semibold">Settings</div>
+          <button id="settingsExit" class="px-3 py-2 rounded-xl border border-border">Exit</button>
+        </div>
+        <div class="rounded-2xl border border-border bg-card text-card-foreground">
+          <div class="p-4 flex flex-col gap-3">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-sm font-medium">Favourite double</div>
+                <div class="text-xs opacity-70">Bias checkout routes (2..40 even, or 50 for Bull)</div>
+              </div>
+              <select id="favDoubleSelect" class="rounded-xl border bg-background px-3 py-2"></select>
+            </div>
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-sm font-medium">Theme</div>
+                <div class="text-xs opacity-70">Follows system by default</div>
+              </div>
+              <div class="flex gap-2">
+                <button id="themeSystem" class="px-3 py-2 rounded-xl border border-border">System</button>
+                <button id="themeLight" class="px-3 py-2 rounded-xl border border-border">Light</button>
+                <button id="themeDark" class="px-3 py-2 rounded-xl border border-border">Dark</button>
+              </div>
+            </div>
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <div class="text-sm font-medium">Sound on checkout</div>
+                <div class="text-xs opacity-70">Tiny beep when leg is won</div>
+              </div>
+              <button id="soundToggle" class="px-3 py-2 rounded-xl border border-border">Off</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlayEl);
+    selectEl = overlayEl.querySelector('#favDoubleSelect');
+    systemBtn = overlayEl.querySelector('#themeSystem');
+    lightBtn = overlayEl.querySelector('#themeLight');
+    darkBtn = overlayEl.querySelector('#themeDark');
+    soundBtn = overlayEl.querySelector('#soundToggle');
+    overlayEl.querySelector('#settingsExit').addEventListener('click', closeSettings);
+    ALL_DOUBLES.forEach((d) => {
+      const opt = document.createElement('option');
+      opt.value = d;
+      opt.textContent = d === 50 ? 'Bull (50)' : `D${d/2} (${d})`;
+      selectEl.appendChild(opt);
+    });
+    selectEl.addEventListener('change', (e) => setSettings({ favouriteDouble: parseInt(e.target.value, 10) }));
+    systemBtn.addEventListener('click', () => setSettings({ theme: 'system' }));
+    lightBtn.addEventListener('click', () => setSettings({ theme: 'light' }));
+    darkBtn.addEventListener('click', () => setSettings({ theme: 'dark' }));
+    soundBtn.addEventListener('click', () => setSettings((s) => ({ sound: !s.sound })));
+  }
+
+  function openSettings() {
+    if (!overlayEl) buildOverlay();
+    updateOverlayUI();
+    overlayEl.classList.remove('hidden');
+  }
+
+  function closeSettings() {
+    if (overlayEl) overlayEl.classList.add('hidden');
+  }
+
+  document.addEventListener('settingschange', updateOverlayUI);
+
+  applyTheme(currentSettings.theme);
+
+  window.Settings = {
+    DEFAULT_SETTINGS,
+    loadSettings,
+    saveSettings,
+    useTheme,
+    useBeep,
+    useSettings,
+    openSettings,
+    setSettings,
+    getSettings
+  };
+})();


### PR DESCRIPTION
## Summary
- add shared `settings.js` with localStorage helpers, hooks, and overlay opener
- show settings gear in the header to access the overlay anywhere
- quickplay uses global settings module instead of local state

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8889c7914832991649ed44b3da2e9