### PR TITLE
Add landing options for future modes

### DIFF
--- a/global-header.js
+++ b/global-header.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
     <nav id="globalMenu" class="hidden flex-col px-4 pb-4 space-y-2" role="navigation">
       <a href="quickplay.html" class="block px-3 py-2 rounded hover:bg-muted focus:bg-muted focus:outline-none">Quick Play</a>
       <a href="#" class="block px-3 py-2 rounded hover:bg-muted focus:bg-muted focus:outline-none" onclick="alert('Training mode coming soon!');return false;">Training Mode</a>
-      <a href="#" class="block px-3 py-2 rounded hover:bg-muted focus:bg-muted focus:outline-none" onclick="alert('Match mode coming soon!');return false;">Match</a>
+      <a href="#" class="block px-3 py-2 rounded hover:bg-muted focus:bg-muted focus:outline-none" onclick="alert('Multiplayer coming soon!');return false;">Multiplayer</a>
     </nav>
   `;
 

--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
           <div class="text-sm opacity-70">Coming soon</div>
           <span class="absolute top-3 right-3 text-xs font-medium px-2 py-1 bg-muted rounded-full">Soon</span>
         </button>
-        <button onclick="alert('Match play coming soon!')" class="relative rounded-2xl bg-card text-card-foreground border border-border p-10 text-center shadow hover:shadow-lg transition">
-          <div class="text-2xl font-semibold mb-2">Match</div>
+        <button onclick="alert('Multiplayer coming soon!')" class="relative rounded-2xl bg-card text-card-foreground border border-border p-10 text-center shadow hover:shadow-lg transition">
+          <div class="text-2xl font-semibold mb-2">Multiplayer</div>
           <div class="text-sm opacity-70">Coming soon</div>
           <span class="absolute top-3 right-3 text-xs font-medium px-2 py-1 bg-muted rounded-full">Soon</span>
         </button>


### PR DESCRIPTION
## Summary
- Rename Match menu to Multiplayer across landing and header
- Show Training Mode and Multiplayer as coming soon on landing page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88b43fecc832997cffe929d797362