### PR TITLE
Remove duplicate header from Quick Play page

### DIFF
--- a/quickplay.html
+++ b/quickplay.html
@@ -41,10 +41,6 @@
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
   <body class="bg-background text-foreground">
-    <script src="header.js"></script>
-    <script>
-      renderHeader();
-    </script>
     <div id="root"></div>
 
     <script type="text/babel">


### PR DESCRIPTION
## Summary
- Remove inline header from Quick Play page now that global header supplies site title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a88b6e9a2c8329a1df8c87cc17a592