### PR TITLE
Increase logo size in global header

### DIFF
--- a/global-header.js
+++ b/global-header.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
   header.innerHTML = `
     <div class="max-w-5xl mx-auto flex items-center justify-between p-4">
       <a href="index.html">
-        <img src="images/DartUpLogoSVG.svg" alt="Darts Scorer Logo" class="h-16 w-auto" />
+        <img src="images/DartUpLogoSVG.svg" alt="Darts Scorer Logo" class="h-24 w-auto" />
       </a>
       <div class="flex items-center gap-2">
         <button id="settingsButton" aria-label="Settings" class="p-2 rounded-md focus:outline-none focus:ring">


### PR DESCRIPTION
## Summary
- enlarge header logo from `h-16` to `h-24` for better visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e26cb1308329a1f311321b26decc