### PR TITLE
feat: offset content by header height

### DIFF
--- a/global-header.js
+++ b/global-header.js
@@ -62,7 +62,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Keep overlay starting below the header
   const setOverlayPadding = () => {
-    overlay.style.paddingTop = `${header.offsetHeight}px`;
+    const h = header.offsetHeight;
+    overlay.style.paddingTop = `${h}px`;
+    document.documentElement.style.setProperty('--header-h', `${h}px`);
   };
   setOverlayPadding();
   window.addEventListener('resize', setOverlayPadding);

--- a/mode-select.html
+++ b/mode-select.html
@@ -32,9 +32,9 @@
     <script src="settings.js"></script>
     <script src="global-header.js" defer></script>
   </head>
-  <body class="bg-background text-foreground">
+    <body class="bg-background text-foreground pt-[var(--header-h)]">
     <!-- Header is injected by global-header.js -->
-    <div class="min-h-screen flex flex-col items-center justify-center gap-10 p-4">
+      <div class="min-h-[calc(100dvh-var(--header-h))] flex flex-col items-center justify-center gap-10 p-4">
       <h1 class="text-3xl font-bold">Select Game Mode</h1>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-5xl">
         <a href="quickplay.html" class="relative rounded-2xl bg-card text-card-foreground border border-border p-10 text-center shadow hover:shadow-lg transition">

--- a/quickplay.html
+++ b/quickplay.html
@@ -40,7 +40,7 @@
     <!-- Babel so we can write JSX here -->
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
-  <body class="bg-background text-foreground">
+    <body class="bg-background text-foreground pt-[var(--header-h)]">
     <div id="root"></div>
 
     <script type="text/babel">
@@ -622,7 +622,7 @@
         const tests = useMemo(() => runTests(), []);
 
         return (
-          <div className="mx-auto max-w-md min-h-[100dvh] bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
+          <div className="mx-auto max-w-md min-h-[calc(100dvh-var(--header-h))] bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
             {/* Score */}
             <header className="flex items-center justify-between gap-3">
               <div>

--- a/training-mode.html
+++ b/training-mode.html
@@ -40,7 +40,7 @@
     <!-- Babel so we can write JSX here -->
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
-  <body class="bg-background text-foreground">
+    <body class="bg-background text-foreground pt-[var(--header-h)]">
     <div id="root"></div>
 
     <script type="text/babel">
@@ -80,7 +80,7 @@
         }
 
         return (
-          <div className="pt-24 flex flex-col items-center gap-6 p-4">
+            <div className="flex flex-col items-center gap-6 p-4">
             {!finished && (
               <>
                 <div className="text-2xl font-bold">


### PR DESCRIPTION
## Summary
- expose global header height via CSS variable
- pad pages below global header and account for it in viewport calculations

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fb0f3b5c8329b825bfa949ec7060