### PR TITLE
Show leg stats popup in quick play

### DIFF
--- a/quickplay.html
+++ b/quickplay.html
@@ -448,6 +448,12 @@
         const totalScored = useMemo(() => START_SCORE - state.currentScore, [state.currentScore]);
         const ppd = dartsThrown > 0 ? totalScored / dartsThrown : 0;
         const threeDA = ppd * 3;
+        const highestScore = useMemo(() => {
+          return state.turns.reduce((max, t) => {
+            const scored = t.isBust ? 0 : t.startScore - t.endScore;
+            return scored > max ? scored : max;
+          }, 0);
+        }, [state.turns]);
 
         // Checkout hint
         const dartsLeftThisTurn = 3 - currentDarts.length;
@@ -506,10 +512,6 @@
           };
           setState(nextState);
           setCurrentDarts([]);
-            if (finished) {
-              showToast(`Leg won in ${dartsThrown + darts.length} darts – 3DA ${threeDA.toFixed(1)}`);
-              resetLeg(true);
-            }
         }
 
         function undoLastDart() {
@@ -760,15 +762,40 @@
             </Card>
 
 
-              {/* Tests & Footer */}
-            <div className="mt-auto pb-2">
-              <div className="text-xs opacity-70">Tests: {tests.passed}/{tests.total} passed{tests.passed !== tests.total ? ` – ${tests.failed.join(", ")}` : ""}</div>
-              <div className="text-[10px] opacity-60 mt-1">Mobile-only UI • Double-out enforced • Edit last 3 turns • Data saved locally</div>
-            </div>
+                {/* Tests & Footer */}
+              <div className="mt-auto pb-2">
+                <div className="text-xs opacity-70">Tests: {tests.passed}/{tests.total} passed{tests.passed !== tests.total ? ` – ${tests.failed.join(", ")}` : ""}</div>
+                <div className="text-[10px] opacity-60 mt-1">Mobile-only UI • Double-out enforced • Edit last 3 turns • Data saved locally</div>
+              </div>
 
-            {/* Edit Drawer */}
-            {editIndex != null && (
-              <div className="fixed inset-0 bg-black/50 flex items-end z-50" role="dialog" aria-modal>
+              {state.status === "gameover" && (
+                <div className="fixed inset-0 flex items-center justify-center bg-black/50 backdrop-blur-sm z-[60]">
+                  <div className="bg-card text-card-foreground p-8 rounded-2xl flex flex-col gap-4 text-center">
+                    <h2 className="text-2xl font-bold">Leg Complete</h2>
+                    <div className="text-lg">Darts Thrown: {dartsThrown}</div>
+                    <div className="text-lg">Highest Score: {highestScore}</div>
+                    <div className="text-lg">3DA: {threeDA.toFixed(1)}</div>
+                    <div className="text-lg">1DA: {ppd.toFixed(1)}</div>
+                    <div className="flex gap-4 pt-2">
+                      <button className="flex-1 px-4 py-2 rounded-xl bg-muted" onClick={() => resetLeg(true)}>
+                        Play Again
+                      </button>
+                      <button
+                        className="flex-1 px-4 py-2 rounded-xl bg-muted"
+                        onClick={() => {
+                          window.location.href = "index.html";
+                        }}
+                      >
+                        Exit
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Edit Drawer */}
+              {editIndex != null && (
+                <div className="fixed inset-0 bg-black/50 flex items-end z-50" role="dialog" aria-modal>
                 <div className="w-full bg-background rounded-t-2xl p-4 border-t max-h-[80dvh] overflow-auto">
                   <div className="flex items-center justify-between mb-2">
                     <div className="font-semibold">Edit Turn #{editIndex + 1}</div>


### PR DESCRIPTION
## Summary
- add highest score and averages to quick play stats
- show leg complete popup with darts thrown, highest score, and averages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a900acec348329878f95bcc6299c9c