### PR TITLE
Fix overlay padding and remove 100dvh to avoid layout shift

### DIFF
--- a/global-header.js
+++ b/global-header.js
@@ -70,6 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.documentElement.style.setProperty('--header-h', `${h}px`);
   };
   setOverlayPadding();
+  window.addEventListener('load', setOverlayPadding);
   window.addEventListener('resize', setOverlayPadding);
 
   const lockScroll = (lock) => {

--- a/mode-select.html
+++ b/mode-select.html
@@ -34,7 +34,7 @@
   </head>
     <body class="bg-background text-foreground pt-[var(--header-h)]">
     <!-- Header is injected by global-header.js -->
-      <div class="min-h-[calc(100dvh-var(--header-h))] flex flex-col items-center justify-center gap-10 p-4">
+      <div class="min-h-[calc(100vh-var(--header-h))] flex flex-col items-center justify-center gap-10 p-4">
       <h1 class="text-3xl font-bold">Select Game Mode</h1>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-5xl">
         <a href="quickplay.html" class="relative rounded-2xl bg-card text-card-foreground border border-border p-10 text-center shadow hover:shadow-lg transition">

--- a/quickplay.html
+++ b/quickplay.html
@@ -636,7 +636,7 @@
         const tests = useMemo(() => runTests(), []);
 
         return (
-          <div className="mx-auto max-w-md min-h-[100dvh] bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
+          <div className="mx-auto max-w-md min-h-screen bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
             {/* Score */}
             <header className="flex items-center justify-between gap-3">
               <div>


### PR DESCRIPTION
## Summary
- Recalculate menu overlay padding after full page load to set correct header offset
- Replace `100dvh` height utilities with `100vh`/`min-h-screen` to prevent mobile layout shifts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a905640fb88329977c0f0e0dced24c