### PR TITLE
Fix training mode scroll offset

### DIFF
--- a/global-header.js
+++ b/global-header.js
@@ -70,6 +70,11 @@ document.addEventListener('DOMContentLoaded', () => {
     document.documentElement.style.setProperty('--header-h', `${h}px`);
   };
   setOverlayPadding();
+  // Ensure the page always starts scrolled to the top. Prepending the header
+  // after the main content can shift the scroll position down, especially on
+  // mobile browsers. Resetting the scroll here keeps the page content visible
+  // without requiring a manual refresh.
+  window.scrollTo(0, 0);
   window.addEventListener('load', setOverlayPadding);
   window.addEventListener('resize', setOverlayPadding);
 


### PR DESCRIPTION
## Summary
- ensure page scroll position resets to top after inserting global header to prevent training mode from starting at bottom

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a907dc282883299d7923356bfad356