### PR TITLE
Add global footer navigation

### DIFF
--- a/global-footer.js
+++ b/global-footer.js
@@ -1,0 +1,48 @@
+// Mobile-only global footer navigation
+// Adds a bottom navigation bar with Home, Quick Play, and Settings icons
+
+document.addEventListener('DOMContentLoaded', () => {
+  const footer = document.createElement('nav');
+  footer.className = 'fixed bottom-0 inset-x-0 z-50 bg-card text-card-foreground border-t border-border';
+  footer.innerHTML = `
+    <div class="mx-auto max-w-5xl flex items-center justify-between p-2">
+      <a href="index.html" aria-label="Home" class="p-2 rounded-md focus:outline-none focus:ring">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M3 9.75L12 3l9 6.75V21a.75.75 0 01-.75.75H3.75A.75.75 0 013 21V9.75z" />
+          <path stroke-linecap="round" stroke-linejoin="round" d="M9 22V12h6v10" />
+        </svg>
+      </a>
+      <a href="quickplay.html" aria-label="Quick Play" class="p-2 rounded-md focus:outline-none focus:ring">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M8 5v14l11-7-11-7z" />
+        </svg>
+      </a>
+      <button id="footerSettingsButton" type="button" aria-label="Settings" class="p-2 rounded-md focus:outline-none focus:ring">
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.591 1.054c1.543-.895 3.37.932 2.475 2.475a1.724 1.724 0 001.055 2.592c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.054 2.591c.895 1.543-.932 3.37-2.475 2.475a1.724 1.724 0 00-2.592 1.055c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.591-1.054c-1.543.895-3.37-.932-2.475-2.475a1.724 1.724 0 00-1.055-2.592c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.054-2.591c-.895-1.543.932-3.37 2.475-2.475a1.724 1.724 0 002.592-1.055z"/>
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
+        </svg>
+      </button>
+    </div>
+  `;
+
+  document.body.appendChild(footer);
+
+  const setFooterHeight = () => {
+    const h = footer.offsetHeight;
+    document.documentElement.style.setProperty('--footer-h', `${h}px`);
+  };
+  setFooterHeight();
+  window.addEventListener('load', setFooterHeight);
+  window.addEventListener('resize', setFooterHeight);
+
+  const settingsBtn = footer.querySelector('#footerSettingsButton');
+  if (settingsBtn) {
+    settingsBtn.addEventListener('click', () => {
+      if (window.Settings && typeof window.Settings.openSettings === 'function') {
+        window.Settings.openSettings();
+      }
+    });
+  }
+});
+

--- a/mode-select.html
+++ b/mode-select.html
@@ -32,10 +32,11 @@
     <script src="settings.js"></script>
     <script src="menu-overlay.js" defer></script>
     <script src="global-header.js" defer></script>
+    <script src="global-footer.js" defer></script>
   </head>
-    <body class="bg-background text-foreground pt-[var(--header-h)]">
+    <body class="bg-background text-foreground pt-[var(--header-h)] pb-[var(--footer-h)]">
     <!-- Header is injected by global-header.js -->
-      <div class="min-h-[calc(100vh-var(--header-h))] flex flex-col items-center justify-center gap-10 p-4">
+      <div class="min-h-[calc(100vh-var(--header-h)-var(--footer-h))] flex flex-col items-center justify-center gap-10 p-4">
       <h1 class="text-3xl font-bold">Select Game Mode</h1>
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-5xl">
         <a href="quickplay.html" class="relative rounded-2xl bg-card text-card-foreground border border-border p-10 text-center shadow hover:shadow-lg transition">

--- a/quickplay.html
+++ b/quickplay.html
@@ -31,6 +31,7 @@
     </style>
 
     <script src="settings.js"></script>
+    <script src="global-footer.js" defer></script>
 
     <!-- React (production) + ReactDOM -->
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
@@ -39,7 +40,7 @@
     <!-- Babel so we can write JSX here -->
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
-    <body class="bg-background text-foreground">
+    <body class="bg-background text-foreground pb-[var(--footer-h)]">
     <header class="fixed top-0 inset-x-0 z-50 bg-card text-card-foreground border-b border-border flex items-center justify-between p-4">
       <a href="index.html" aria-label="Back" class="p-2 rounded-md focus:outline-none focus:ring">
         <svg class="w-6 h-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
@@ -53,7 +54,7 @@
         </svg>
       </button>
     </header>
-    <div id="root" class="pt-16"></div>
+    <div id="root" class="pt-16 pb-[var(--footer-h)]"></div>
 
     <script type="text/babel">
       const { useEffect, useMemo, useRef, useState } = React;

--- a/training-mode.html
+++ b/training-mode.html
@@ -33,6 +33,7 @@
     <script src="settings.js"></script>
     <script src="menu-overlay.js" defer></script>
     <script src="global-header.js" defer></script>
+    <script src="global-footer.js" defer></script>
 
     <!-- React (production) + ReactDOM -->
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
@@ -41,7 +42,7 @@
     <!-- Babel so we can write JSX here -->
     <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   </head>
-    <body class="bg-background text-foreground pt-[var(--header-h)]">
+    <body class="bg-background text-foreground pt-[var(--header-h)] pb-[var(--footer-h)]">
     <div id="root"></div>
 
     <script type="text/babel">


### PR DESCRIPTION
## Summary
- Add reusable footer script that injects bottom navigation with Home, Quick Play, and Settings actions
- Load footer across app pages and pad layouts to account for its height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a90c2ed57c832980e11b8a5ef0c8d8