### PR TITLE
Force mobile layout across devices

### DIFF
--- a/mode-select.html
+++ b/mode-select.html
@@ -38,7 +38,7 @@
     <!-- Header is injected by global-header.js -->
       <div class="min-h-[calc(100vh-var(--header-h))] flex flex-col items-center justify-center gap-10 p-4">
       <h1 class="text-3xl font-bold">Select Game Mode</h1>
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6 w-full max-w-5xl">
+      <div class="grid grid-cols-1 gap-6 w-full max-w-5xl">
         <a href="quickplay.html" class="relative rounded-2xl bg-card text-card-foreground border border-border p-10 text-center shadow hover:shadow-lg transition">
           <div class="text-2xl font-semibold mb-2">Quick Play</div>
           <div class="text-sm opacity-70">Jump right into a leg</div>

--- a/quickplay.html
+++ b/quickplay.html
@@ -637,7 +637,7 @@
         const tests = useMemo(() => runTests(), []);
 
         return (
-          <div className="mx-auto max-w-md min-h-screen bg-background text-foreground p-3 sm:p-4 flex flex-col gap-3">
+          <div className="mx-auto max-w-md min-h-screen bg-background text-foreground p-3 flex flex-col gap-3">
             {/* Score */}
             <header className="flex items-center justify-between gap-3">
               <div>


### PR DESCRIPTION
## Summary
- Remove responsive grid on mode selection page so layout stays single-column
- Drop small-screen padding rule in quickplay view to keep consistent mobile spacing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a910595e808329a684e18e3ad1f55c