### PR TITLE
Remove footer from non-menu pages

### DIFF
--- a/quickplay.html
+++ b/quickplay.html
@@ -31,8 +31,6 @@
     </style>
 
     <script src="settings.js"></script>
-    <script src="global-footer.js" defer></script>
-
     <!-- React (production) + ReactDOM -->
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>

--- a/training-mode.html
+++ b/training-mode.html
@@ -31,8 +31,6 @@
     </style>
 
       <script src="settings.js"></script>
-      <script src="global-footer.js" defer></script>
-
     <!-- React (production) + ReactDOM -->
     <script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
     <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>


### PR DESCRIPTION
## Summary
- Keep mobile footer navigation only on the game mode selection page
- Remove footer script from Quick Play and Training Mode screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a911423758832986c7df62b8940f0d